### PR TITLE
Fix/replace old organization links (extends #6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,70 @@
+language: go
+go_import_path: github.com/ethereumclassic/go-ethereum
+
+go: 1.10
+os:
+- linux
+- osx
+before_install:
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository ppa:duggan/bats --yes; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq bats; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bats; fi
+
+script: |
+    export GOPATH=$HOME/go
+    export GOBIN=$GOPATH/bin
+    mkdir -p $GOBIN
+    go version
+    go env
+    export TAGS="netgo deterministic"
+
+    export USE_SPUTNIK_VM=true
+    if [ $USE_SPUTNIK_VM == true ]; then
+      export CGO_LDFLAGS="$GOPATH/src/github.com/ethereumclassic/go-ethereum/vendor/github.com/ETCDEVTeam/sputnikvm-ffi/c/libsputnikvm.a -ldl"
+      if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+        export CGO_LDFLAGS="$CGO_LDFLAGS -lresolv"
+      fi
+      export TAGS="sputnikvm $TAGS"
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+      export PATH=$PATH:$HOME/.cargo/bin
+      cd $GOPATH/src/github.com/ethereumclassic/go-ethereum
+      make -C vendor/github.com/ETCDEVTeam/sputnikvm-ffi/c
+    fi
+
+    go test -ldflags "-X github.com/ethereumclassic/go-ethereum/core.UseSputnikVM=$USE_SPUTNIK_VM" -tags="$TAGS" ./...
+    go get github.com/etcdevteam/go-schroedinger/cmd/schroedinger/...
+    schroedinger -t 5 -f ./schroedinger-tests.txt
+
+    export CGO_LDFLAGS="$GOPATH/src/github.com/ethereumclassic/go-ethereum/vendor/github.com/ETCDEVTeam/sputnikvm-ffi/c/libsputnikvm.a -ldl"
+    if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      export CGO_LDFLAGS="$CGO_LDFLAGS -lresolv"
+    else
+      export EXT_LD_FLAGS="-extldflags=-static"
+    fi
+    cd $GOPATH/src/github.com/ethereumclassic/go-ethereum
+    go build -tags="sputnikvm netgo" -ldflags "$EXT_LD_FLAGS -X main.Version=`janus version -format TAG_OR_NIGHTLY`" ./cmd/geth
+    cp ./geth $GOPATH/bin/
+    bats tests/bats
+
+    if [ ! -x ~/janusbin/janus ]; then
+      cd $HOME; curl -sL https://raw.githubusercontent.com/ethereumclassic/janus/master/get.sh | bash
+      cd $GOPATH/src/github.com/ethereumclassic/go-ethereum
+    fi
+    export PATH=$PATH:$HOME/janusbin
+    export VERSION=`janus version -format TAG_OR_NIGHTLY`
+    ./geth version | awk '/^Version: /{if (ENVIRON["VERSION"] != $2){printf "Expected: \"%s\", got \"%s\"\n",ENVIRON["VERSION"], $2; exit 1}}'
+
+    zip geth-classic-$TRAVIS_OS_NAME-$VERSION.zip geth
+    sed -E "s/APPVERSION/$VERSION/" bintray.tpl.json > bintray.json
+
+deploy:
+  provider: bintray
+  file: "bintray.json"
+  user: realcodywburns
+  key:
+    secure: #TODO # "c50TvgsSeBMs8LoPO6nQVad3rie0Csh9l2KmwBCCZCLnJNA2nRTMM4EvlNiO8XiYKxms5h3KbzkZXCm+LCmsf+H8U0yupb44prg/MZ8HdvHQ4Qh/hEfQ8rESlxsgu6fjDjF779ge4gfYImyXHkBOCn/PoLkw+Akzw18l2dxsBnAecc+dHwBQ8NQ1Wh7CulD05DEG4SmdMuA/urj4f3kQGkb03jLF8/dNlf8HlTfgREaeKP9rpAtAKsoRIVC+34FdRWN/i8KG3TY+A3+M8bzIFCVNx+sXQ5YKbbtRQbuLPZPF/ELBWsMaxxHwlujhEbsBbZVkHGGZtKk8/EU1w9ZkEQWghXnkIuDxpqvSHzl491xhhpbf+7XL/uonAHlatoNDu3822vrp/eDj/Ys4vOF7F8dYQ7JIyhmXN/P3khehG7FG8mDBqXuImPtiltqvLBGMbsgUFIlaugaB45Zr/Oe2Umf97MgNJeSW/U5qLXN7sS4fPA/KAquty9yzFaxhgsY9iKiGJdAS6AC/CJxmhzEJWgwu6idAmN/L5BaRg29YTtaK+D6AwIVCky9hyHn0VhFN+ieF8H3P3fweG8PX4i63oqTs0+sAGGygzcN6xNit9NtJQ7i3QeGlzRIXfCh2cMz0pU5ErZrWy+kNH1ixzpW9VyugAl6qUQxnyIhbbY5ybIQ="
+  on:
+    branch: master
+tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script: |
       export EXT_LD_FLAGS="-extldflags=-static"
     fi
     cd $GOPATH/src/github.com/ethereumclassic/go-ethereum
+
     go build -tags="sputnikvm netgo" -ldflags "$EXT_LD_FLAGS -X main.Version=`janus version -format TAG_OR_NIGHTLY`" ./cmd/geth
     cp ./geth $GOPATH/bin/
     bats tests/bats
@@ -54,10 +55,11 @@ script: |
     fi
     export PATH=$PATH:$HOME/janusbin
     export VERSION=`janus version -format TAG_OR_NIGHTLY`
+    export VERSION_BASE=`janus.exe version -format='v%M.%m.x'`
     ./geth version | awk '/^Version: /{if (ENVIRON["VERSION"] != $2){printf "Expected: \"%s\", got \"%s\"\n",ENVIRON["VERSION"], $2; exit 1}}'
 
     zip geth-classic-$TRAVIS_OS_NAME-$VERSION.zip geth
-    sed -E "s/APPVERSION/$VERSION/" bintray.tpl.json > bintray.json
+    sed -E "s/APPVERSION/$VERSION_BASE/" bintray.tpl.json > bintray.json
 
 deploy:
   provider: bintray

--- a/accounts/manager_easyjson.go
+++ b/accounts/manager_easyjson.go
@@ -4,7 +4,6 @@ package accounts
 
 import (
 	json "encoding/json"
-
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
@@ -18,7 +17,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonEd74d837DecodeGithubComEthereumprojectGoEthereumAccounts(in *jlexer.Lexer, out *AccountJSON) {
+func easyjsonEd74d837DecodeGithubComEthereumclassicGoEthereumAccounts(in *jlexer.Lexer, out *AccountJSON) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -53,51 +52,63 @@ func easyjsonEd74d837DecodeGithubComEthereumprojectGoEthereumAccounts(in *jlexer
 		in.Consumed()
 	}
 }
-func easyjsonEd74d837EncodeGithubComEthereumprojectGoEthereumAccounts(out *jwriter.Writer, in AccountJSON) {
+func easyjsonEd74d837EncodeGithubComEthereumclassicGoEthereumAccounts(out *jwriter.Writer, in AccountJSON) {
 	out.RawByte('{')
 	first := true
 	_ = first
-	if !first {
-		out.RawByte(',')
+	{
+		const prefix string = ",\"address\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Address))
 	}
-	first = false
-	out.RawString("\"address\":")
-	out.String(string(in.Address))
-	if !first {
-		out.RawByte(',')
+	{
+		const prefix string = ",\"key\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.EncryptedKey))
 	}
-	first = false
-	out.RawString("\"key\":")
-	out.String(string(in.EncryptedKey))
-	if !first {
-		out.RawByte(',')
+	{
+		const prefix string = ",\"file\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.File))
 	}
-	first = false
-	out.RawString("\"file\":")
-	out.String(string(in.File))
 	out.RawByte('}')
 }
 
 // MarshalJSON supports json.Marshaler interface
 func (v AccountJSON) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
-	easyjsonEd74d837EncodeGithubComEthereumprojectGoEthereumAccounts(&w, v)
+	easyjsonEd74d837EncodeGithubComEthereumclassicGoEthereumAccounts(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AccountJSON) MarshalEasyJSON(w *jwriter.Writer) {
-	easyjsonEd74d837EncodeGithubComEthereumprojectGoEthereumAccounts(w, v)
+	easyjsonEd74d837EncodeGithubComEthereumclassicGoEthereumAccounts(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
 func (v *AccountJSON) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
-	easyjsonEd74d837DecodeGithubComEthereumprojectGoEthereumAccounts(&r, v)
+	easyjsonEd74d837DecodeGithubComEthereumclassicGoEthereumAccounts(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
 func (v *AccountJSON) UnmarshalEasyJSON(l *jlexer.Lexer) {
-	easyjsonEd74d837DecodeGithubComEthereumprojectGoEthereumAccounts(l, v)
+	easyjsonEd74d837DecodeGithubComEthereumclassicGoEthereumAccounts(l, v)
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,16 +48,36 @@ build_script:
   - ps: >-
       .\geth.exe version | Where {$_ -match "^Version: "} | %{$actual=($_ -split "\s+")[1];If($actual -ne $env:VERSION){"Expected: `"$env:VERSION`", got: `"$ACTUAL`""; exit 1}}
   - 7z a geth-classic-win64-%VERSION%.zip geth.exe
-before_deploy:
-  # Set up GCP upload.
-  - ps: >-
-      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumclassic/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
-        nuget install secure-file -ExcludeVersion
-        secure-file\tools\secure-file -decrypt gcloud-appveyor.json.enc -secret "$env:GCP_PASSWD" -out .gcloud.json
-      }
-# Deploy on APPVEYOR_REPO_BRANCH=master or APPVEYOR_REPO_TAG=true
-deploy_script:
-  - ps: >-
-      If (($env:APPVEYOR_REPO_NAME -eq 'ethereumclassic/go-ethereum') -and (($env:APPVEYOR_REPO_BRANCH -eq 'master') -or ($env:APPVEYOR_REPO_TAG -eq 'true'))) {
-        janus.exe deploy -to="builds.etcdevteam.com/go-ethereum/$env:VERSION_BASE/" -files="./*.zip" -key="./.gcloud.json"
-      }
+
+artifacts:
+  - path: '*.zip'
+    name: geth
+# https://www.appveyor.com/docs/deployment/bintray/
+# for reference (from back when ethereumproject used to use bintray): https://github.com/ethereumclassic/go-ethereum/blob/c3dc48237e1e3200f575d1e7b17354ea5b8163fd/appveyor.yml
+deploy:
+- provider: BinTray
+  username: realcodywburns
+  api_key:
+    secure: #TODO # AABBCC+DDD==
+  subject: ethereumclassic
+  repo: Go-ethereum
+  package: go-ethereum #TODO: set me up on Bintray (> name of package to upload artifacts to. Deployment will fail if specified package does not exists.)
+  version: %VERSION_BASE%
+  publish: true
+  override: true
+  explode: false
+  on:
+    branch: master
+- provider: BinTray
+  username: realcodywburns
+  api_key:
+    secure: #TODO # AABBCC+DDD==
+  subject: ethereumclassic
+  repo: Go-ethereum
+  package: go-ethereum #TODO: set me up on Bintray (> name of package to upload artifacts to. Deployment will fail if specified package does not exists.)
+  version: %VERSION_BASE%
+  publish: true
+  override: true
+  explode: false
+  on:
+    appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,7 +62,7 @@ deploy:
   subject: ethereumclassic
   repo: Go-ethereum
   package: go-ethereum #TODO: set me up on Bintray (> name of package to upload artifacts to. Deployment will fail if specified package does not exists.)
-  version: %VERSION_BASE%
+  version: "%VERSION_BASE%"
   publish: true
   override: true
   explode: false
@@ -75,7 +75,7 @@ deploy:
   subject: ethereumclassic
   repo: Go-ethereum
   package: go-ethereum #TODO: set me up on Bintray (> name of package to upload artifacts to. Deployment will fail if specified package does not exists.)
-  version: %VERSION_BASE%
+  version: "%VERSION_BASE%"
   publish: true
   override: true
   explode: false

--- a/bintray.tpl.json
+++ b/bintray.tpl.json
@@ -1,0 +1,18 @@
+{
+  "package": {
+    "name": "go-ethereum",
+    "repo": "Go-ethereum",
+    "subject": "ethereumclassic"
+  },
+
+  "version": {
+    "name": "APPVERSION",
+    "attributes": [],
+    "gpgSign": false
+  },
+
+  "files": [
+    {"includePattern": "./(geth.+\\.zip)", "uploadPattern": "/$1"}
+  ],
+  "publish": true
+}


### PR DESCRIPTION
This is just an 'extension' PR from @phyro 's #6 since I don't have permissions to push to upstream branches. 

Progress above #6 includes fixing a generated file for `mailru/easyjson` in accounts/manager.go and getting a start on setting up [AppVeyor->Bintray and Travis->Bintray distribution channels](https://github.com/ethereumclassic/DevOps#bintray). (The CI configs are a start, but knowing how CI setups usually go, they'll probably need some further revisions. And [the Travis one-enormous-script](https://github.com/ethereumclassic/go-ethereum/compare/fix/replace-old-organization-links...whilei:fix/replace-old-organization-links?expand=1#diff-354f30a63fb0907d4ad57269548329e3R15) is really ugly - it should be "yaml-fied" - this is just an early hybrid of [an old ethereumproject/go-ethereum .travis.yml](https://github.com/ethereumclassic/go-ethereum/blob/d0b885516ead6e46f084cc60e4298997b2a8b196/.travis.yml) and [the current .circleci/config.yml](https://github.com/ethereumclassic/go-ethereum/blob/master/.circleci/config.yml).)

@realcodywburns There are a few places we'll need your administration here - both AppVeyor and Travis need `key.secret`s to be configured for Bintray deploys, and it looks like you'll need to set up a 'Package' named `go-ethereum` on https://bintray.com/ethereumclassic/Go-ethereum because [the Bintray deploy docs](https://www.appveyor.com/docs/deployment/bintray/) say they'll fail without that pre-existing.

