### PR TITLE
core: add missing mlog-reorgs instance to registry

### DIFF
--- a/core/mlog.go
+++ b/core/mlog.go
@@ -14,6 +14,7 @@ var mlogTxPool = logger.MLogRegisterAvailable("txpool", mLogLinesTxPool)
 var mLogLinesBlockchain = []*logger.MLogT{
 	mlogBlockchainWriteBlock,
 	mlogBlockchainInsertBlocks,
+	mlogBlockchainReorgBlocks,
 }
 
 var mLogLinesHeaderchain = []*logger.MLogT{


### PR DESCRIPTION
Caused existing mlog `blockchain.reorgs` endpoint to not get exposed, just because missing variable name in `mlogLinesBlockchain` registry.